### PR TITLE
Allow for extensible path generators

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -1,27 +1,29 @@
-fun main() {
-    val paths = ArrayList<PathGen>()
-    val deadEnd = PathGenDeadEndLine()
-    val verticalLine = PathGenVerticalLine()
-    val spiral = PathGenSpiral()
-    val horizontalLine = PathGenHorizontalLine()
-    val lShapeLine = PathGenLShapeLine()
-    val square = PathGenSquare()
-    paths.add(deadEnd)
-    paths.add(verticalLine)
-    paths.add(spiral)
-    paths.add(horizontalLine)
-    paths.add(lShapeLine)
-    paths.add(square)
-
-    val game = Game(20, 0, 0, 0, 0, 9, paths)
-    println(game.maze)
-}
+import java.lang.NumberFormatException
+import kotlin.system.exitProcess
 
 class Main {
     companion object {
         @JvmStatic
         fun main(args: Array<String>) {
-            main()
+            if (args.size != 1) {
+                System.err.println("Error\n\tUsage: java -jar Maze.jar <path mode>")
+                exitProcess(1)
+            }
+
+            val pathMode = try {
+                args[0].toInt()
+            } catch (e: NumberFormatException) {
+                System.err.println ("Error\n\t${args[0]} is not a valid number")
+                exitProcess(2)
+            }.apply {
+                if (!PathFactory.valid(this)) {
+                    System.err.println ("Error\n\t${this} is an invalid path mode")
+                    exitProcess(3)
+                }
+            }
+
+            val game = Game(20, 0, 0, 0, 0, 9, PathFactory.generate(pathMode))
+            println(game.maze)
         }
     }
 }

--- a/src/main/kotlin/PathFactory.kt
+++ b/src/main/kotlin/PathFactory.kt
@@ -1,0 +1,23 @@
+object PathFactory {
+    private var generator : List<()-> List<PathGen>> = listOf (
+        {
+            listOf(
+                PathGenDeadEndLine(),
+                PathGenVerticalLine(),
+                PathGenSpiral(),
+                PathGenHorizontalLine(),
+                PathGenLShapeLine(),
+                PathGenSquare()
+            )
+        },
+        {
+            listOf(
+               NullPathGen()
+            )
+        }
+    )
+
+    fun generate(idx: Int) : List<PathGen> = generator[idx]()
+
+    fun valid(idx: Int) = idx < generator.size && idx >= 0
+}

--- a/src/main/kotlin/PathGen.kt
+++ b/src/main/kotlin/PathGen.kt
@@ -1,3 +1,10 @@
 interface PathGen {
     fun generate(maze: Array<IntArray>, entryX: Int, entryY: Int)
 }
+
+class NullPathGen : PathGen {
+    override fun generate(maze: Array<IntArray>, entryX: Int, entryY: Int) {
+        // Purposefully do nothing
+        return
+    }
+}


### PR DESCRIPTION
Add a PathGenerator Factory to allow multiple path generator modes to be
set. Add command line (super janky) parsing to allow selection of a path
generator mode.

Add a NullPathGen as some default option